### PR TITLE
Fixed: Passing a `MessageProvider` in `Alexa.create` will cause an Exception

### DIFF
--- a/alexa_web_api_for_games/CHANGELOG.md
+++ b/alexa_web_api_for_games/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Allow the use of the DefaultMessageProvider when creating a Alexa create object.
+
 ## 1.0.1
 
 - Fixed typos in documentation.

--- a/alexa_web_api_for_games/README.md
+++ b/alexa_web_api_for_games/README.md
@@ -143,7 +143,6 @@ void _messageReceivedCallback(MessageSendResponse sendResponse) {
 
 ## Known Issues
 
-- As stated above, passing a `MessageProvider` in `Alexa.create` will cause an Exception.
 - Currently Extensions are not supported.
 - For more know issues, please see https://developer.amazon.com/en-US/docs/alexa/web-api-for-games/known-issues.html.
 

--- a/alexa_web_api_for_games/lib/alexa_web_api.dart
+++ b/alexa_web_api_for_games/lib/alexa_web_api.dart
@@ -24,24 +24,16 @@ typedef MessageSendResponseCallback = void Function(
 ///
 /// Messages are passed from device to browser from script evaluation via a known function
 /// which defaults to window.__dispatchMessage.
-@anonymous
 @JS()
-abstract class DefaultMessageProvider implements MessageProvider {
-  /// Initializes the message provider with the given options.
-  /// In most cases, users should not have to supply their own options for these values.
-  external factory DefaultMessageProvider({
-    dynamic /* undefined | { apiUrl?: undefined | string; dispatchFunc?: undefined | string; urlLengthLimit?: undefined | number } */ options,
-    String? urlLengthLimit,
-  });
+class DefaultMessageProvider implements MessageProvider {
+  external DefaultMessageProvider(
+      [dynamic /* undefined | { apiUrl?: undefined | string; dispatchFunc?: undefined | string; urlLengthLimit?: undefined | number } */ options]);
 
   @override
-  set receive(MessageCallback callback);
+  external set receive(MessageCallback callback);
 
   @override
-  dynamic /* Promise<MessageSendResponse> */ send(
-    String command, [
-    payload,
-  ]);
+  external send(String command, payload);
 
   @JS('DEFAULT_RATELIMIT_MAX_REQUEST_PER_SEC')
   external List<String> get defaultRatelimitMaxRequestPerSec;
@@ -60,7 +52,7 @@ abstract class DefaultMessageProvider implements MessageProvider {
 }
 
 @JS('create')
-external AlexaReadyPayload _create(CreateClientOptions option);
+external PromiseJsImpl<AlexaReadyPayload> _create(CreateClientOptions option);
 
 @JS('utils')
 external Utils _utils;
@@ -254,7 +246,6 @@ abstract class Message<T> {
 }
 
 /// Message interface that any device or mock device must fulfill to integrate with [Client].
-@anonymous
 @JS()
 abstract class MessageProvider {
   /// Register the callback for when events from the device are received.
@@ -271,7 +262,7 @@ abstract class MessageProvider {
     dynamic payload,
   );
 
-  external factory MessageProvider();
+  external MessageProvider();
 }
 
 /// The status of the message sent to the device.
@@ -518,4 +509,14 @@ class ErrorCode {
   static const String unauthorizedAccess = 'unauthorized-access';
   static const String tooManyRequests = 'too-many-requests';
   static const String unknown = 'unknown';
+}
+
+@JS('Promise')
+class PromiseJsImpl<T> {
+  external PromiseJsImpl(Function resolver);
+
+  external PromiseJsImpl then([
+    void Function(dynamic) onResolve,
+    void Function(dynamic) onReject,
+  ]);
 }


### PR DESCRIPTION
- **Please check if the PR fulfils these requirements**

* [X] Docs have been added or updated
* [X] Updated for bug fixes
* [ ] Updated for features
* [ ] Other

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A Bugfix that resolves the problem in `What is the current behavior?`. When a `DefaultMessageProvider` or  a `MessageProvider` object is supplied as a `messageProvider`argument for the `CreateClientOptions` object (as seen in `Figure 1`), ` Figure 2` shows the expected behavior (no TypeError errors).

```dart
AlexaReadyPayload payload = await Alexa.create(
  CreateClientOptions(
    version: '1.1',
    messageProvider: DefaultMessageProvider(),
  ),
);
```
Figure 1. Code Snippet

![image](https://user-images.githubusercontent.com/15693006/192921564-897112f5-e6ef-496d-8a03-3d8423c9995c.png)
Figure 2. Shows the  expected behavior


- **What is the current behavior (the bug)?**
When a `DefaultMessageProvider` or  a `MessageProvider` object is supplied as a `messageProvider`argument for the `CreateClientOptions` object (as seen in `Figure 3`), ` Figure 4` shows the error message produced.
```dart
AlexaReadyPayload payload = await Alexa.create(
  CreateClientOptions(
    version: '1.1',
    messageProvider: DefaultMessageProvider(),
  ),
);
```
Figure 3. Code Snippet

![image](https://user-images.githubusercontent.com/15693006/192920210-075d214c-f841-4f53-aff4-f145bcff0c97.png)
Figure 4. The error message is produced when a `DefaultMessageProvider` object is used as an argument.


- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 No breaking changes
